### PR TITLE
Disable scale to zero

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -5,8 +5,8 @@ functions:
   cloudevents-interop-demo:
     lang: golang-http
     handler: ./function
-    image: rgee0/cloudevents-interop-demo:latest
+    image: rgee0/cloudevents-interop-demo:0.1
+    labels:
+      com.openfaas.scale.zero: false
     environment: 
       wordsURL : https://srcdog.com/madlibs/words.txt
-
-


### PR DESCRIPTION
Disable scale to zero to prevent timing out during
demos.

I suggest you add this to any other repos you may be doing demos from.

Signed-off-by: Alex Ellis <alexellis2@gmail.com>